### PR TITLE
feat: add OAuth token refreshing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -472,7 +472,8 @@ export class M3ter extends Core.APIClient {
   // This is the earliest async hook we have to obtain a token, before the `authHeaders` is called
   // on the request.
   protected override async prepareOptions(options: Core.FinalRequestOptions): Promise<void> {
-    const tokenValid = !!this.token && this.tokenExpiry && this.tokenExpiry > new Date();
+    // When manually setting the token we won't have a `tokenExpiry` so consider that valid.
+    const tokenValid = !!this.token && (!this.tokenExpiry || this.tokenExpiry > new Date());
 
     // Prevent infinite loop of token requests.
     if (!tokenValid && !options.path.endsWith('/oauth/token')) {


### PR DESCRIPTION
Store the token expiry date and check it's still valid before making any requests. If it isn't then we get a new token in the same way as the initial token.